### PR TITLE
Security hardening: fix XSS, broken access control, and crypto weaknesses

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,13 +26,16 @@ let redisStore = new RedisStore({ client: redisClient })
 
 let session = ExpressSession({
   cookie: {
-    maxAge: config.sessionValidFor
+    maxAge: config.sessionValidFor,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: config.https.enabled
   },
   resave: true,
-  saveUninitialized: true,
+  saveUninitialized: false,
   rolling: true,
   secret: config.sessionSecret,
-  store: redisStore 
+  store: redisStore
 });
 
 var sass = require('sass');
@@ -52,9 +55,6 @@ if (config.https.enabled) {
   var server = https.createServer(options, app).listen(config.listen.port, function () {
     console.log("Express server listening on port " + config.listen.port);
   });
-  if (app.get('env') === 'production') {
-    session.cookie.secure = true; // serve secure cookies
-  }
 } else {
   http = require('http')
   app = express()
@@ -167,6 +167,11 @@ app.use(function (req, res, next) {
   res.header('Cache-Control', 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0, max-age=0')
   res.header('Expires', '-1')
   res.header('Pragma', 'no-cache')
+
+  //baseline hardening headers
+  res.header('X-Content-Type-Options', 'nosniff')
+  res.header('X-Frame-Options', 'SAMEORIGIN')
+  res.header('Referrer-Policy', 'same-origin')
   next();
 });
 
@@ -491,8 +496,14 @@ app.get('/folder/:folderId?', middleware.isLogged, middleware.checkFolderAcl, fu
           }
         });
 
+        //SVG (and XML-based images) can carry embedded <script>; never serve
+        //them inline as that would execute in the dashboard's origin (stored XSS).
+        //Such files keep their attachment Content-Disposition and are downloaded.
+        var ctype = res.get('Content-Type') || '';
+        var inlineSafe = ctype.search('svg') == -1 && ctype.search('xml') == -1;
+
         view_types.forEach(function (t) {
-          if (res.get('Content-Type').search(t) != -1) {
+          if (inlineSafe && ctype.search(t) != -1) {
             res.set('Content-Disposition', '')
           }
         });

--- a/app.js
+++ b/app.js
@@ -183,21 +183,6 @@ var linkCodeProvider = new LinkCodeProvider();
 var middleware = require('./middleware');
 middleware.setup(userProvider, deviceProvider, folderProvider, linkCodeProvider);
 
-var env = process.env.NODE_ENV || 'development';
-if ('development' == env) {
-  app.use(require('errorhandler')({
-    dumpExceptions: true,
-    showStack: true
-  }));
-}
-
-if ('production' == env) {
-  app.use(require('errorhandler')({
-    dumpExceptions: false,
-    showStack: false
-  }));
-}
-
 // Routes
 app.all(/^(?!\/api\/).+/, function (req, res, next) {
   session(req, res, next);
@@ -759,6 +744,9 @@ app.get('/stylesheets', function (req, res, next) {
 app.get('*', function (req, res, next) {
   next(new errors.NotFound(req.url));
 });
+
+// error handler must be registered after all routes so next(err) reaches it
+app.use(errors.errorHandler);
 
 function runApp() {
   app.listen(config.listen.port, config.listen.host, function () {

--- a/app.js
+++ b/app.js
@@ -551,7 +551,7 @@ app.get('/folder/:folderId?', middleware.isLogged, middleware.checkFolderAcl, fu
   }
 });
 
-app.post('/putFile/:folderId', middleware.isLogged, function (req, res, next) {
+app.post('/putFile/:folderId', [middleware.isLogged, middleware.checkFolderAcl], function (req, res, next) {
   if (!req.params.folderId) {
     return next(new Error('No folder id given'))
   } else {

--- a/backend/git.js
+++ b/backend/git.js
@@ -291,6 +291,12 @@ GitBackend.prototype = {
       path = '';
     }
 
+    //a supplied tree-ish must be a full git object hash; reject anything else
+    //so it can't be interpreted as a git option (argument injection)
+    if (baseHash && !baseHash.match(/^[a-f0-9]{40}$/)) {
+      return next(new Error('Invalid hash'));
+    }
+
     var mybackend = this;
     function getItemsFromHere(baseHash, path, next) {
       var execPath = path;
@@ -298,14 +304,14 @@ GitBackend.prototype = {
         baseHash = 'HEAD';
       }
 
-      mybackend.execGit(['ls-tree', '-z', '-l', baseHash, '.'], function(error, data) {
+      mybackend.execGit(['ls-tree', '-z', '-l', baseHash, '--', '.'], function(error, data) {
         if (error) { return next(error); }
         parseList(data, path, next);
       });
     }
 
     if (!baseHash && path) {
-      this.execGit(['ls-tree', '-z', '-l', 'HEAD', path], function(error, data) {
+      this.execGit(['ls-tree', '-z', '-l', 'HEAD', '--', path], function(error, data) {
         if (error) { return next(error); }
         parseList(data, path, function(error, list) {
           if (error) { return next(error); }

--- a/deviceProvider.js
+++ b/deviceProvider.js
@@ -1,4 +1,5 @@
 var errors = require('./error');
+var crypto = require('crypto');
 
 DeviceProvider = function(redisClient) {
   this.rclient = redisClient;
@@ -188,8 +189,10 @@ Device.prototype = {
     var chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_";
     var salt = '';
 
+    // use a cryptographically secure RNG for auth tokens / identifiers
+    var bytes = crypto.randomBytes(len);
     for (var i=0; i < len; i++) {
-      salt += chars.charAt(Math.floor(Math.random() * chars.length));
+      salt += chars.charAt(bytes[i] % chars.length);
     }
     return salt;
   },
@@ -203,7 +206,15 @@ Device.prototype = {
   },
 
   checkAuthCode: function(authCode) {
-    return this.authCode == authCode;
+    if (typeof authCode !== 'string' || typeof this.authCode !== 'string') {
+      return false;
+    }
+    var a = Buffer.from(this.authCode);
+    var b = Buffer.from(authCode);
+    if (a.length !== b.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(a, b);
   }
 };
 

--- a/error.js
+++ b/error.js
@@ -33,6 +33,9 @@ function Conflict(msg) {
 util.inherits(Conflict, Error);
 
 function errorHandler(err, req, res, next) {
+  var name = err.name;
+  var message = err.message;
+
   if (err instanceof NotFound) {
     res.statusCode = 404;
   } else if (err instanceof Permission) {
@@ -40,23 +43,27 @@ function errorHandler(err, req, res, next) {
   } else if (err instanceof Conflict) {
     res.statusCode = 409;
   } else {
+    // unexpected error: log details server-side, but show a generic message
+    // to the client so we don't leak internals (paths, git stderr, stacks)
     res.statusCode = 500;
-    return next();
+    console.error(err && err.stack ? err.stack : err);
+    name = 'Internal Server Error';
+    message = 'Internal Server Error';
   }
 
   var accept = req.headers.accept || '';
   if (~accept.indexOf('html')) {
     // html
-    res.render('error', { e: err });
+    res.render('error', { e: { name: name, message: message } });
   } else if (~accept.indexOf('json')) {
     // json
-    var json = JSON.stringify({ error: err.name, msg: err.message });
+    var json = JSON.stringify({ error: name, msg: message });
     res.setHeader('Content-Type', 'application/json');
     res.end(json);
   } else {
     // plain text
     res.setHeader('Content-Type', 'text/plain');
-    res.end(err.name + ": " + err.message);
+    res.end(name + ": " + message);
   }
 }
 

--- a/example-config.js
+++ b/example-config.js
@@ -1,3 +1,8 @@
+// Secret used to sign session cookies. Use a long, random, secret value and
+// keep it private: anyone who knows it can forge session cookies.
+// Generate one with, e.g.:
+//   openssl rand -base64 48
+//   node -e "console.log(require('crypto').randomBytes(48).toString('base64'))"
 exports.sessionSecret = 'JustSomeRandomString';
 
 exports.folders = [

--- a/linkCodeProvider.js
+++ b/linkCodeProvider.js
@@ -1,4 +1,5 @@
 var config = require('./config');
+var crypto = require('crypto');
 
 LinkCodeProvider = function() {
   this.validCodes = [];
@@ -11,7 +12,9 @@ LinkCodeProvider.prototype = {
   getNewCode: function(uid) {
     this.gc();
 
-    var code = Math.floor(Math.random() * Math.pow(10, this.codeLen)).toString();
+    // cryptographically secure, uniformly distributed numeric code
+    var max = Math.pow(10, this.codeLen);
+    var code = crypto.randomInt(0, max).toString();
     code = (new Array(this.codeLen - code.length + 1)).join("0") + code;
 
     this.validCodes.push({

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "connect-flash": "^0.1.x",
         "connect-redis": "^4.0.x",
         "cookie-parser": "^1.4.x",
-        "errorhandler": "^1.5.x",
         "express": "^4.22.x",
         "express-session": "^1.17.x",
         "i18n": "^0.15.x",
@@ -771,18 +770,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/errorhandler": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
-      "integrity": "sha512-rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==",
-      "dependencies": {
-        "accepts": "~1.3.7",
-        "escape-html": "~1.0.3"
-      },
       "engines": {
         "node": ">= 0.8"
       }
@@ -2539,15 +2526,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
-    },
-    "errorhandler": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
-      "integrity": "sha512-rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==",
-      "requires": {
-        "accepts": "~1.3.7",
-        "escape-html": "~1.0.3"
-      }
     },
     "es-define-property": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "connect-flash": "^0.1.x",
     "connect-redis": "^4.0.x",
     "cookie-parser": "^1.4.x",
-    "errorhandler": "^1.5.x",
     "express": "^4.22.x",
     "express-session": "^1.17.x",
     "i18n": "^0.15.x",

--- a/users/local.js
+++ b/users/local.js
@@ -24,8 +24,18 @@ LocalUserProvider = function (options, redisClient, deviceProvider) {
   })
 }
 
+// legacy password hash (single-round HMAC-SHA256) kept only to verify
+// passwords stored before the scrypt migration
 function hash(msg, key) {
   return crypto.createHmac('sha256', key).update(msg).digest('hex');
+}
+
+var SCRYPT_KEYLEN = 64;
+
+// scrypt-based password hash, self-describing format: scrypt$<saltHex>$<hashHex>
+function scryptHash(password, saltBuf) {
+  var derived = crypto.scryptSync(String(password), saltBuf, SCRYPT_KEYLEN);
+  return 'scrypt$' + saltBuf.toString('hex') + '$' + derived.toString('hex');
 }
 
 LocalUserProvider.prototype = {
@@ -215,31 +225,34 @@ User = function (data) {
 };
 
 User.prototype = {
-  genSalt: function (len) {
-    var chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
-    var salt = '';
-
-    // use a cryptographically secure RNG for the password salt
-    var bytes = crypto.randomBytes(len);
-    for (var i = 0; i < len; i++) {
-      salt += chars.charAt(bytes[i] % chars.length);
-    }
-    return salt;
-  },
-
   setPassword: function (password) {
-    var salt = this.genSalt(8);
-    this.pass = hash(password, salt);
-    this.salt = salt;
+    // store using scrypt; salt is embedded in the hash string
+    this.pass = scryptHash(password, crypto.randomBytes(16));
+    this.salt = '';
   },
 
   checkPassword: function (password) {
-    var expected = Buffer.from(this.pass);
-    var actual = Buffer.from(hash(password, this.salt));
-    if (expected.length !== actual.length) {
+    if (typeof this.pass !== 'string' || this.pass.length === 0) {
       return false;
     }
-    return crypto.timingSafeEqual(expected, actual);
+
+    // new scrypt format: scrypt$<saltHex>$<hashHex>
+    if (this.pass.indexOf('scrypt$') === 0) {
+      var parts = this.pass.split('$');
+      if (parts.length !== 3) {
+        return false;
+      }
+      var saltBuf = Buffer.from(parts[1], 'hex');
+      var expected = Buffer.from(parts[2], 'hex');
+      var actual = crypto.scryptSync(String(password), saltBuf, expected.length);
+      return expected.length === actual.length && crypto.timingSafeEqual(expected, actual);
+    }
+
+    // legacy HMAC-SHA256 format (verified in constant time, upgraded on next change)
+    var legacyExpected = Buffer.from(this.pass);
+    var legacyActual = Buffer.from(hash(password, this.salt));
+    return legacyExpected.length === legacyActual.length &&
+      crypto.timingSafeEqual(legacyExpected, legacyActual);
   }
 };
 

--- a/users/local.js
+++ b/users/local.js
@@ -219,8 +219,10 @@ User.prototype = {
     var chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
     var salt = '';
 
+    // use a cryptographically secure RNG for the password salt
+    var bytes = crypto.randomBytes(len);
     for (var i = 0; i < len; i++) {
-      salt += chars.charAt(Math.floor(Math.random() * chars.length));
+      salt += chars.charAt(bytes[i] % chars.length);
     }
     return salt;
   },
@@ -232,7 +234,12 @@ User.prototype = {
   },
 
   checkPassword: function (password) {
-    return this.pass == hash(password, this.salt);
+    var expected = Buffer.from(this.pass);
+    var actual = Buffer.from(hash(password, this.salt));
+    if (expected.length !== actual.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(expected, actual);
   }
 };
 

--- a/views/preview.pug
+++ b/views/preview.pug
@@ -28,9 +28,9 @@ block main
             });
 
     div#preview-box
-        pre !{data}
+        pre= data
 
     form(action=basepath + '/putFile/'+parent.id+'?path='+path, method='post')
-        textarea(name='content').edit-box !{data}
+        textarea(name='content').edit-box= data
         input(type='submit', value=__i('Save file')).edit-save
 


### PR DESCRIPTION
## Summary

  Security review of the whole codebase plus the fixes. Three commits:

  1. Core vulnerabilities found in review
  2. Second-pass hardening from a full-codebase sweep
  3. Error-handling cleanup + config docs

  No functional changes to normal usage. Existing logins keep working
  (password hashes are verified in a backward-compatible way and upgraded
  to scrypt on next change).

  ## Security fixes

  | # | Issue | Severity | Fix |
  |---|-------|----------|-----|
  | 1 | **Stored XSS** in file preview — repo file content rendered with unescaped `!{data}` | High | Escape with `= data` in `preview.pug` |
  | 2 | **Stored XSS** via inline SVG — file-view route served `image/svg+xml` inline; SVG can embed `<script>` | High | SVG/XML images now download instead of rendering
  inline |
  | 3 | **Broken access control** — web `/putFile` route lacked the folder-ACL check the API routes use | High | Add `checkFolderAcl` to the route |
  | 4 | **Insecure randomness** — auth codes, device idents, link codes, and password salts used `Math.random()` | Medium | Use `crypto.randomBytes` / `crypto.randomInt` |
  | 5 | **Weak password KDF** — single-round HMAC-SHA256 | Medium | scrypt, with backward-compatible verification of legacy hashes |
  | 6 | **Git argument injection** — unvalidated tree-ish + no `--` separator in `ls-tree` | Medium | Validate hash to 40-hex, add `--` before pathspecs |
  | 7 | **Timing-unsafe comparisons** of auth codes / password hashes | Low | `crypto.timingSafeEqual` |
  | 8 | **Session cookie hardening** — `secure` flag was set on the middleware function (no-op); no `httpOnly`/`sameSite` | Medium | Set `httpOnly`, `sameSite=lax`, working
  `secure`; `sameSite=lax` mitigates cross-site CSRF |
  | 9 | **Info leak on 500** — error handler could surface internal details (paths, git stderr) | Low | Log server-side, return a generic message |

  Also added `X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy`
  response headers.

  ## Cleanup

  - Removed the `errorhandler` npm middleware — it was registered before the
    routes (so `next(err)` never reached it) and was dead code. Wired the
    purpose-built `error.js` handler after all routes instead.
  - Documented `sessionSecret` generation in `example-config.js`.

  ## Not included (recommended follow-ups)

  - **CSRF tokens** on state-changing POST routes — `sameSite=lax` covers the
    main vector for now; token-based CSRF would add defense-in-depth.
  - **Content-Security-Policy** — would defang both XSS paths, but needs nonces
    because of inline `<script>` in templates (a dedicated refactor).
  - Confirm the deployed `config.js` doesn't still use the example
    `sessionSecret`.

  ## Testing

  - All modified files pass `node --check`.
  - scrypt + legacy password verification verified with a round-trip test
    (correct/incorrect for both formats).
  - `package.json` / `package-lock.json` valid and in sync.