### PR TITLE
read the device name the clients actually send

### DIFF
--- a/api.js
+++ b/api.js
@@ -10,8 +10,23 @@ Api = function(app, dp, fp, mw) {
   folderProvider = fp;
   middleware = mw;
 
-  app.post('/api/getAuthCode', middleware.validateLinkCode, function(req, res) {
-    deviceProvider.createNew(req.query.name, req.linkCodeForUid, function(error, dev) {
+  app.post('/api/getAuthCode', middleware.validateLinkCode, function(req, res, next) {
+    //the clients post the device name in the form body alongside the link code;
+    //only the query string was read before, so every device linked from a phone
+    //was stored nameless and showed up as "", " (1)", " (2)" in the device list.
+    //The query string is still accepted for anything that sends it there.
+    var name = (req.body && req.body.name) || req.query.name;
+    if (typeof name !== 'string') {
+      name = '';
+    }
+
+    deviceProvider.createNew(name, req.linkCodeForUid, function(error, dev) {
+      //without this an error left dev undefined, and the TypeError below came
+      //out of a promise callback - an unhandled rejection, which is fatal
+      if (error) {
+        return next(error);
+      }
+
       res.json({
         ident: dev.ident,
         authCode: dev.authCode


### PR DESCRIPTION
`/api/getAuthCode` read the device name from the **query string**, but the
mobile clients post it in the **form body** next to the link code
([`SSConnection.m:194`](https://github.com/kjyv/SparkleShare-iOS) builds
`code=…&name=…` and sends it as `application/x-www-form-urlencoded`).

So the name was silently dropped for every device linked from a phone. Those
devices were stored nameless and showed up in Linked Devices as `""`, then
`" (1)"`, `" (2)"` — `findUniqueNameForUid` appending its disambiguating
counter to an empty string. This predates the recent security work; I ran into
it while checking the client for incompatibilities.

The body is now preferred, and the query string is still accepted so anything
sending it there keeps working. A name arriving as something other than a
string — repeated or bracketed form fields yield an array or an object — is
treated as absent rather than passed to redis, which rejects non-string
arguments.

Also checks the error from `createNew`, which was ignored: a failure left `dev`
undefined and the property access below threw a `TypeError` from inside a
promise callback. That is an unhandled rejection, which terminates the process
on current node versions.